### PR TITLE
Add Prometheus metrics export and Grafana monitoring stack

### DIFF
--- a/les_core.py
+++ b/les_core.py
@@ -1,0 +1,89 @@
+"""Core LES process with Prometheus metrics export.
+
+This script simulates LES metrics such as water chemistry and
+simulation throughput and exposes them via the Prometheus
+client on an HTTP endpoint.
+
+Run this file directly to start the metrics server and update
+metrics in a simple loop.  Use the ``--iterations`` argument
+for a finite number of iterations; by default it runs
+indefinitely.
+"""
+from __future__ import annotations
+
+import argparse
+import random
+import time
+
+from prometheus_client import Counter, Gauge, start_http_server
+
+# Gauges for current state measurements
+water_ph = Gauge("water_ph", "Current water pH level")
+dissolved_oxygen = Gauge(
+    "dissolved_oxygen_mg_per_l",
+    "Dissolved oxygen concentration in mg/L",
+)
+
+# Throughput and counts
+simulation_steps_total = Counter(
+    "simulation_steps_total", "Total number of simulation steps processed"
+)
+simulation_throughput = Gauge(
+    "simulation_throughput_steps_per_second", "Simulation steps per second"
+)
+
+
+def run_metrics_server(port: int) -> None:
+    """Start the Prometheus metrics HTTP server."""
+    start_http_server(port)
+
+
+def simulate(iterations: int | None = None, delay: float = 1.0) -> None:
+    """Update metrics in a loop.
+
+    Parameters
+    ----------
+    iterations:
+        Number of simulation iterations to perform. ``None`` runs indefinitely.
+    delay:
+        Seconds to wait between iterations.
+    """
+    start_time = time.time()
+    steps = 0
+    while iterations is None or steps < iterations:
+        # Simulate readings
+        water_ph.set(7.0 + random.uniform(-0.3, 0.3))
+        dissolved_oxygen.set(8.0 + random.uniform(-1.0, 1.0))
+
+        # Update counters and throughput
+        simulation_steps_total.inc()
+        steps += 1
+        elapsed = time.time() - start_time
+        if elapsed > 0:
+            simulation_throughput.set(steps / elapsed)
+
+        time.sleep(delay)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Port for Prometheus metrics HTTP server"
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=None,
+        help="Number of simulation iterations; default runs indefinitely",
+    )
+    parser.add_argument(
+        "--delay", type=float, default=1.0, help="Delay between iterations in seconds"
+    )
+    args = parser.parse_args()
+
+    run_metrics_server(args.port)
+    simulate(iterations=args.iterations, delay=args.delay)
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,46 @@
+# Monitoring
+
+This directory provides a minimal observability stack for the
+Living Environment System (LES).  Metrics from the core LES
+process are exported via the [`prometheus_client`](https://github.com/prometheus/client_python)
+library and visualised in Grafana.
+
+## Starting the Stack
+
+1. Ensure the LES metrics server is running:
+
+   ```bash
+   pip install -r requirements.txt
+   python les_core.py --iterations 0  # runs indefinitely
+   ```
+
+   The metrics endpoint will be available at `http://localhost:8000/metrics`.
+
+2. Start Prometheus and Grafana:
+
+   ```bash
+   cd grafana
+   docker-compose up
+   ```
+
+   * Prometheus will be available at <http://localhost:9090>.
+   * Grafana will be available at <http://localhost:3000> (default login `admin` / `admin`).
+
+3. Grafana automatically loads the dashboard defined in
+   [`dashboard.json`](grafana/dashboard.json) and connects to the
+   Prometheus data source.
+
+## Alerting
+
+Example alerting rules are provisioned in
+[`provisioning/alerting/rules.yml`](grafana/provisioning/alerting/rules.yml).
+These include simple warnings for high pH and critically low
+dissolved oxygen.  Alerts can be customised through Grafana's
+alerting interface once the stack is running.
+
+## How LES Pushes Metrics
+
+The core `les_core.py` process uses `prometheus_client` gauges and
+counters to expose water chemistry and simulation throughput
+statistics.  Prometheus scrapes these metrics and stores them for
+visualisation and alerting.

--- a/monitoring/grafana/dashboard.json
+++ b/monitoring/grafana/dashboard.json
@@ -1,0 +1,33 @@
+{
+  "id": null,
+  "title": "LES Metrics",
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Water pH",
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "water_ph", "refId": "A"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Dissolved Oxygen (mg/L)",
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "dissolved_oxygen_mg_per_l", "refId": "A"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Simulation Throughput (steps/s)",
+      "gridPos": {"x": 0, "y": 8, "w": 24, "h": 8},
+      "targets": [
+        {"expr": "simulation_throughput_steps_per_second", "refId": "A"}
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/docker-compose.yml
+++ b/monitoring/grafana/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning
+      - ./dashboard.json:/var/lib/grafana/dashboards/dashboard.json
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/dashboard.json

--- a/monitoring/grafana/prometheus.yml
+++ b/monitoring/grafana/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'les'
+    static_configs:
+      - targets: ['host.docker.internal:8000']

--- a/monitoring/grafana/provisioning/alerting/rules.yml
+++ b/monitoring/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,33 @@
+apiVersion: 1
+groups:
+  - name: les_alerts
+    interval: 1m
+    rules:
+      - uid: ph_high
+        title: High pH Level
+        condition: A
+        data:
+          - refId: A
+            datasourceUid: prometheus
+            model:
+              expr: water_ph > 7.5
+              instant: true
+        for: 1m
+        annotations:
+          summary: pH level too high
+        labels:
+          severity: warning
+      - uid: low_do
+        title: Low Dissolved Oxygen
+        condition: A
+        data:
+          - refId: A
+            datasourceUid: prometheus
+            model:
+              expr: dissolved_oxygen_mg_per_l < 5
+              instant: true
+        for: 1m
+        annotations:
+          summary: Dissolved oxygen below safe threshold
+        labels:
+          severity: critical

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: 'LES'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+prometheus_client>=0.16


### PR DESCRIPTION
## Summary
- instrument core LES loop with Prometheus metrics for water chemistry and throughput
- add monitoring stack using docker-compose with Prometheus and Grafana
- provide example dashboard and alert rules plus documentation for running the stack

## Testing
- `pip install prometheus_client` *(fails: Could not find a version that satisfies the requirement prometheus_client)*
- `python les_core.py --iterations 1` *(fails: ModuleNotFoundError: No module named 'prometheus_client')*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898cbc643f08322a5cf34d0415b85c7