### PR TITLE
Add CI workflow for linting and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Lint
+        run: flake8 .
+      - name: Test
+        run: pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+flake8
+pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running flake8 and pytest on push and pull requests
- add development requirements file for linting and testing packages

## Testing
- `flake8 .` *(fails: command not found)*
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c717584948322a85dc1455d5a4469