### PR TITLE
Add simulation metrics test

### DIFF
--- a/tests/test_simulate_metrics.py
+++ b/tests/test_simulate_metrics.py
@@ -1,0 +1,21 @@
+from les_core import (
+    simulate,
+    water_ph,
+    dissolved_oxygen,
+    simulation_steps_total,
+    simulation_throughput,
+)
+
+
+def test_simulate_updates_metrics():
+    initial_ph = water_ph._value.get()
+    initial_oxygen = dissolved_oxygen._value.get()
+    initial_steps = simulation_steps_total._value.get()
+    initial_throughput = simulation_throughput._value.get()
+
+    simulate(iterations=2, delay=0)
+
+    assert water_ph._value.get() != initial_ph
+    assert dissolved_oxygen._value.get() != initial_oxygen
+    assert simulation_steps_total._value.get() > initial_steps
+    assert simulation_throughput._value.get() != initial_throughput


### PR DESCRIPTION
## Summary
- add test to ensure `simulate()` updates pH, oxygen, and throughput metrics

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c7173bc0c8322bbbc5c2f4726e969